### PR TITLE
Speed up the border detection process

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,1 +1,4 @@
-gemspec
+source 'https://rubygems.org'
+ruby '2.3.0'
+gem 'rmagick', '>= 2.13.1'
+gem 'rake', '>= 10.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,5 @@
-PATH
-  remote: .
-  specs:
-    map_data_extractor (0.4.0)
-      rake (>= 10.1.0)
-      rmagick (>= 2.13.1)
-
 GEM
+  remote: https://rubygems.org/
   specs:
     rake (10.1.0)
     rmagick (2.13.2)
@@ -14,4 +8,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  map_data_extractor!
+  rake (>= 10.1.0)
+  rmagick (>= 2.13.1)
+
+RUBY VERSION
+   ruby 2.3.0p0
+
+BUNDLED WITH
+   1.12.5

--- a/lib/map_data_extractor.rb
+++ b/lib/map_data_extractor.rb
@@ -4,7 +4,7 @@ module MapDataExtractor
 
   def self.color_code(pixel)
     # Rmagick uses 16-bit depth by default. 8-bit in some configuration.
-    divider = Magick::QuantumDepth == 16 ? 257 : 1
+    divider = Magick::MAGICKCORE_QUANTUM_DEPTH == 16 ? 257 : 1
     [
       '#',
       (pixel.red   / divider).to_s(16).rjust(2, '0'),

--- a/lib/map_data_extractor/borders_extractor.rb
+++ b/lib/map_data_extractor/borders_extractor.rb
@@ -35,23 +35,31 @@ class MapDataExtractor::BordersExtractor
 
   private
 
+  NEIGHBOR_OFFSETS = [
+    [-1, -1],
+    [ 0, -1],
+    [ 1, -1],
+    [-1,  0],
+    [ 1,  0],
+    [-1,  1],
+    [ 0,  1],
+    [ 1,  1]
+  ]
+
+  def each_neighbor(x, y)
+    point = [0, 0]
+    NEIGHBOR_OFFSETS.each do |offsets|
+      point[0] = x + offsets[0]
+      point[1] = y + offsets[1]
+      yield(point)
+    end
+  end
+
   # Return the first point with the given color around given coordinates.
   def point_with_color_around(color, origin_point, points_to_ignore = [])
-    x, y = origin_point
-
-    [
-      [ x - 1, y - 1 ],
-      [ x,     y - 1 ],
-      [ x + 1, y - 1 ],
-      [ x - 1, y     ],
-      [ x + 1, y     ],
-      [ x - 1, y + 1 ],
-      [ x,     y + 1 ],
-      [ x + 1, y + 1 ]
-    ].each do |point|
+    each_neighbor(*origin_point) do |point|
       return point if !points_to_ignore.include?(point) && @image.pixel_color(*point) == color
     end
-
     nil
   end
 end


### PR DESCRIPTION
Hi !

My attention got caught by the `point_with_color_around` method. Seems like a new point array is created for each tested pixel.

So just in order to make it faster and more memory effiicient, I propose to update that into a static offset based system.

Also, I pimped the Gemfile to have it working on my machine